### PR TITLE
Get some new attributes when calling hooks

### DIFF
--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -76,16 +76,16 @@ abstract class DataTablesEditor
             }
 
             $model = $instance->newQuery()->create($data);
-            $model->setAttribute('DT_RowId', $model->getKey());
 
             if (method_exists($this, 'created')) {
-                $this->created($model, $data);
+                $model = $this->created($model, $data);
             }
 
             if (method_exists($this, 'saved')) {
-                $this->saved($model, $data);
+                $model = $this->saved($model, $data);
             }
 
+            $model->setAttribute('DT_RowId', $model->getKey());
             $affected[] = $model;
         }
 
@@ -200,11 +200,11 @@ abstract class DataTablesEditor
             $model->update($data);
 
             if (method_exists($this, 'updated')) {
-                $this->updated($model, $data);
+                $model = $this->updated($model, $data);
             }
 
             if (method_exists($this, 'saved')) {
-                $this->saved($model, $data);
+                $model = $this->saved($model, $data);
             }
 
             $model->setAttribute('DT_RowId', $model->getKey());


### PR DESCRIPTION
When calling updated and created callback hooks there might be some new data to add to the model.
This is where I felt like a deadend when I was working with "serverSide: false" in datatables which will not reload the data after edit or create and use the response from the server. So I had to add some columns to the returning data to fix it and this parts that I've added might be good for other usages too.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-editor/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
