### PR TITLE
Creating and Saving hooks are not saving the $data changes.

### DIFF
--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -75,8 +75,6 @@ abstract class DataTablesEditor
                 continue;
             }
 
-            $instance->fill($data);
-
             if (method_exists($this, 'creating')) {
                 $data = $this->creating($instance, $data);
             }
@@ -85,7 +83,7 @@ abstract class DataTablesEditor
                 $data = $this->saving($instance, $data);
             }
 
-            $instance->save();
+            $instance->fill($data)->save();
 
             if (method_exists($this, 'created')) {
                 $instance = $this->created($instance, $data);
@@ -211,8 +209,6 @@ abstract class DataTablesEditor
                 continue;
             }
 
-            $model->fill($data);
-
             if (method_exists($this, 'updating')) {
                 $data = $this->updating($model, $data);
             }
@@ -221,7 +217,7 @@ abstract class DataTablesEditor
                 $data = $this->saving($model, $data);
             }
 
-            $model->save();
+            $model->fill($data)->save();
 
             if (method_exists($this, 'updated')) {
                 $model = $this->updated($model, $data);


### PR DESCRIPTION
There is a problem that $data changes made in creating/saving and updating/saving hooks are not getting added in database.

This is because of a recent change where `$instance->fill($data);` is called before calling the hooks.

This was breaking code in my production server.