### PR TITLE
Add support for handling field type upload and uploadMany.

### DIFF
--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -425,15 +425,16 @@ abstract class DataTablesEditor
      */
     public function upload(Request $request)
     {
+        $field   = $request->input('uploadField');
+        $storage = Storage::disk($this->disk);
+
         try {
-            $type       = $request->input('uploadField');
-            $filesystem = Storage::disk($this->disk);
             $rules      = $this->uploadRules();
-            $fieldRules = ['upload' => data_get($rules, $type, [])];
+            $fieldRules = ['upload' => data_get($rules, $field, [])];
 
             $this->validate($request, $fieldRules, $this->uploadMessages(), $this->attributes());
 
-            $id = $filesystem->putFile($this->uploadDir, $request->file('upload'));
+            $id = $storage->putFile($this->uploadDir, $request->file('upload'));
 
             if (method_exists($this, 'uploaded')) {
                 $id = $this->uploaded($id);
@@ -446,15 +447,13 @@ abstract class DataTablesEditor
                     'size'      => $request->file('upload')->getSize(),
                     'directory' => $this->uploadDir,
                     'disk'      => $this->disk,
-                    'url'       => $filesystem->url($id),
+                    'url'       => $storage->url($id),
                 ],
                 'upload' => [
                     'id' => $id,
                 ],
             ]);
         } catch (ValidationException $exception) {
-            $field = $request->get('uploadField');
-
             return response()->json([
                 'data'        => [],
                 'fieldErrors' => [

--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -82,7 +82,7 @@ abstract class DataTablesEditor
         $connection->beginTransaction();
         foreach ($request->get('data') as $data) {
             $validator = $this->getValidationFactory()
-                              ->make($data, $this->createRules(), $this->createMessages(), $this->attributes());
+                              ->make($data, $this->createRules(), $this->createMessages() + $this->messages(), $this->attributes());
             if ($validator->fails()) {
                 foreach ($this->formatErrors($validator) as $error) {
                     $errors[] = $error;
@@ -148,6 +148,7 @@ abstract class DataTablesEditor
     /**
      * Get create validation messages.
      *
+     * @deprecated deprecated since v1.12.0, please use messages() instead.
      * @return array
      */
     protected function createMessages()
@@ -216,7 +217,7 @@ abstract class DataTablesEditor
         foreach ($request->get('data') as $key => $data) {
             $model     = $this->getBuilder()->findOrFail($key);
             $validator = $this->getValidationFactory()
-                              ->make($data, $this->editRules($model), $this->editMessages(), $this->attributes());
+                              ->make($data, $this->editRules($model), $this->editMessages() + $this->messages(), $this->attributes());
             if ($validator->fails()) {
                 foreach ($this->formatErrors($validator) as $error) {
                     $errors[] = $error;
@@ -283,6 +284,7 @@ abstract class DataTablesEditor
     /**
      * Get edit validation messages.
      *
+     * @deprecated deprecated since v1.12.0, please use messages() instead.
      * @return array
      */
     protected function editMessages()
@@ -306,7 +308,7 @@ abstract class DataTablesEditor
         foreach ($request->get('data') as $key => $data) {
             $model     = $this->getBuilder()->findOrFail($key);
             $validator = $this->getValidationFactory()
-                              ->make($data, $this->removeRules($model), $this->removeMessages(), $this->attributes());
+                              ->make($data, $this->removeRules($model), $this->removeMessages() + $this->messages(), $this->attributes());
             if ($validator->fails()) {
                 foreach ($this->formatErrors($validator) as $error) {
                     $errors[] = $error['status'];
@@ -362,6 +364,7 @@ abstract class DataTablesEditor
     /**
      * Get remove validation messages.
      *
+     * @deprecated deprecated since v1.12.0, please use messages() instead.
      * @return array
      */
     protected function removeMessages()
@@ -477,11 +480,11 @@ abstract class DataTablesEditor
     }
 
     /**
-     * Upload validation messages.
+     * Get validation messages.
      *
      * @return array
      */
-    protected function uploadMessages()
+    protected function messages()
     {
         return [];
     }

--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -82,7 +82,7 @@ abstract class DataTablesEditor
         $connection->beginTransaction();
         foreach ($request->get('data') as $data) {
             $validator = $this->getValidationFactory()
-                              ->make($data, $this->createRules(), $this->createMessages() + $this->messages(), $this->attributes());
+                              ->make($data, $this->createRules(),  $this->messages() + $this->createMessages(), $this->attributes());
             if ($validator->fails()) {
                 foreach ($this->formatErrors($validator) as $error) {
                     $errors[] = $error;
@@ -217,7 +217,7 @@ abstract class DataTablesEditor
         foreach ($request->get('data') as $key => $data) {
             $model     = $this->getBuilder()->findOrFail($key);
             $validator = $this->getValidationFactory()
-                              ->make($data, $this->editRules($model), $this->editMessages() + $this->messages(), $this->attributes());
+                              ->make($data, $this->editRules($model), $this->messages() + $this->editMessages(), $this->attributes());
             if ($validator->fails()) {
                 foreach ($this->formatErrors($validator) as $error) {
                     $errors[] = $error;
@@ -308,7 +308,7 @@ abstract class DataTablesEditor
         foreach ($request->get('data') as $key => $data) {
             $model     = $this->getBuilder()->findOrFail($key);
             $validator = $this->getValidationFactory()
-                              ->make($data, $this->removeRules($model), $this->removeMessages() + $this->messages(), $this->attributes());
+                              ->make($data, $this->removeRules($model), $this->messages() + $this->removeMessages(), $this->attributes());
             if ($validator->fails()) {
                 foreach ($this->formatErrors($validator) as $error) {
                     $errors[] = $error['status'];


### PR DESCRIPTION
- Add support for handling field type `upload` and `uploadMany`.
- Fix #17.
- Deprecated the following methods: `createMessages()`, `editMessages()`, `removeMessages()` and refactor it to one method `messages()`.


