### PR TITLE
fix: display of multiple errors when doing batch action

### DIFF
--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -136,8 +136,8 @@ abstract class DataTablesEditor
         ];
 
         if ($error) {
-            $code = 422;
-            $response['error'] = $error;
+            $code = 400;
+            $response['error'] = '<div class="DTE_Form_Error_Item">'.implode('</div><br class="DTE_Form_Error_Separator" /><div>', (array) $error).'</div>';
         }
 
         if ($errors) {

--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -14,7 +14,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 /**
- * @template TModelClass of Model
+ * @template TModel of Model
  */
 abstract class DataTablesEditor
 {
@@ -52,7 +52,7 @@ abstract class DataTablesEditor
     protected array $customActions = [];
 
     /**
-     * @var null|class-string<\Illuminate\Database\Eloquent\Model>|Model
+     * @var null|class-string<TModel>|TModel
      */
     protected $model = null;
 
@@ -167,7 +167,7 @@ abstract class DataTablesEditor
     /**
      * Set the dataTables model on runtime.
      *
-     * @param  class-string<Model>|Model  $model
+     * @param  class-string<TModel>|TModel  $model
      */
     public function setModel(Model|string $model): static
     {
@@ -201,7 +201,7 @@ abstract class DataTablesEditor
     /**
      * Get eloquent builder of the model.
      *
-     * @return \Illuminate\Database\Eloquent\Builder<TModelClass>
+     * @return \Illuminate\Database\Eloquent\Builder<TModel>
      */
     protected function getBuilder(): Builder
     {
@@ -217,6 +217,8 @@ abstract class DataTablesEditor
 
     /**
      * Resolve model to used.
+     *
+     * @return TModel
      */
     protected function resolveModel(): Model
     {

--- a/src/DataTablesEditorException.php
+++ b/src/DataTablesEditorException.php
@@ -4,6 +4,4 @@ namespace Yajra\DataTables;
 
 use Exception;
 
-class DataTablesEditorException extends Exception
-{
-}
+class DataTablesEditorException extends Exception {}

--- a/tests/Feature/DataTablesEditorTest.php
+++ b/tests/Feature/DataTablesEditorTest.php
@@ -17,7 +17,7 @@ class DataTablesEditorTest extends TestCase
         $this->expectException(DataTablesEditorException::class);
         $this->expectExceptionMessage('Requested action (invalid) not supported!');
 
-        $editor = new UsersDataTableEditor();
+        $editor = new UsersDataTableEditor;
         request()->merge(['action' => 'invalid']);
         $editor->process(request());
     }
@@ -25,7 +25,7 @@ class DataTablesEditorTest extends TestCase
     #[Test]
     public function it_can_set_model_class_via_runtime()
     {
-        $editor = new UsersDataTableEditor();
+        $editor = new UsersDataTableEditor;
         $this->assertEquals(User::class, $editor->getModel());
         $editor->setModel(Post::class);
         $this->assertEquals(Post::class, $editor->getModel());
@@ -34,7 +34,7 @@ class DataTablesEditorTest extends TestCase
     #[Test]
     public function it_can_set_model_instance_via_runtime()
     {
-        $editor = new UsersDataTableEditor();
+        $editor = new UsersDataTableEditor;
         $editor->setModel(new Post);
         $this->assertEquals(new Post, $editor->getModel());
     }


### PR DESCRIPTION
This PR aims to fix the rendering of multiple errors encountered during a batch action. Added a div container for each error and break separator.