### PR TITLE
Fixed missing concern

### DIFF
--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -22,6 +22,7 @@ abstract class DataTablesEditor
     use Concerns\WithEditAction;
     use Concerns\WithForceDeleteAction;
     use Concerns\WithRemoveAction;
+    use Concerns\WithRestoreAction;
     use Concerns\WithUploadAction;
     use ValidatesRequests;
 


### PR DESCRIPTION
DataTablesEditor was missing the restore function, now its included.