### PR TITLE
feat: custom action class

### DIFF
--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -90,12 +90,12 @@ abstract class DataTablesEditor
     /**
      * Process dataTables editor action request.
      *
-     * @return JsonResponse
-     *
-     * @throws DataTablesEditorException
+     * @throws \Yajra\DataTables\DataTablesEditorException
      */
-    public function process(Request $request): mixed
+    public function process(?Request $request = null): JsonResponse
     {
+        $request ??= request();
+
         if ($request->get('action') && is_string($request->get('action'))) {
             $this->action = $request->get('action');
         } else {

--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -48,7 +48,7 @@ abstract class DataTablesEditor
     /**
      * List of custom editor actions.
      *
-     * @var array<string, class-string|string>
+     * @var array<array-key, string|class-string>
      */
     protected array $customActions = [];
 

--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -127,7 +127,7 @@ abstract class DataTablesEditor
     /**
      * Display success data in dataTables editor format.
      */
-    protected function toJson(array $data, array $errors = [], string|array $error = ''): JsonResponse
+    public function toJson(array $data, array $errors = [], string|array $error = ''): JsonResponse
     {
         $code = 200;
 

--- a/src/DataTablesEditor.php
+++ b/src/DataTablesEditor.php
@@ -188,6 +188,7 @@ abstract class DataTablesEditor
 
         return $this;
     }
+
     /**
      * Get validation messages.
      */

--- a/tests/Editors/Remove2FA.php
+++ b/tests/Editors/Remove2FA.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Editors;
+
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class Remove2FA
+{
+    public function handle(Request $request): JsonResponse
+    {
+        return new JsonResponse([
+            'message' => '2FA has been removed successfully.',
+        ]);
+    }
+}

--- a/tests/Editors/Remove2FA.php
+++ b/tests/Editors/Remove2FA.php
@@ -2,7 +2,6 @@
 
 namespace Yajra\DataTables\Tests\Editors;
 
-
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 

--- a/tests/Editors/UsersDataTableEditor.php
+++ b/tests/Editors/UsersDataTableEditor.php
@@ -13,6 +13,10 @@ class UsersDataTableEditor extends DataTablesEditor
 {
     protected $model = User::class;
 
+    protected array $customActions = [
+        'remove2fa' => Remove2FA::class,
+    ];
+
     /**
      * Get create action validation rules.
      */

--- a/tests/Feature/DataTablesEditorActionTest.php
+++ b/tests/Feature/DataTablesEditorActionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Feature;
+
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\Tests\TestCase;
+
+class DataTablesEditorActionTest extends TestCase
+{
+    #[Test]
+    public function it_can_process_custom_action_request()
+    {
+        $response = $this->postJson('users', [
+            'action' => 'remove2fa',
+            'data' => [],
+        ]);
+
+        $data = $response->json();
+        $this->assertArrayHasKey('message', $data);
+        $this->assertEquals('2FA has been removed successfully.', $data['message']);
+    }
+}

--- a/tests/Feature/DataTablesEditorTest.php
+++ b/tests/Feature/DataTablesEditorTest.php
@@ -15,7 +15,7 @@ class DataTablesEditorTest extends TestCase
     public function it_throws_exception_on_invalid_action()
     {
         $this->expectException(DataTablesEditorException::class);
-        $this->expectExceptionMessage('Requested action (invalid) not supported!');
+        $this->expectExceptionMessage('Invalid action requested!');
 
         $editor = new UsersDataTableEditor;
         request()->merge(['action' => 'invalid']);


### PR DESCRIPTION
This PR aims to add the following ability for Editor.

* Delegate action to its own class.

## Editor
```php
    protected array $customActions = [
        'remove2fa' => Actions\Remove2FA::class,
        'changePassword',
    ];
```

## Action

```php
use Illuminate\Http\JsonResponse;
use Illuminate\Http\Request;

class Remove2FA
{
    public function handle(Request $request): JsonResponse
    {
        return new JsonResponse([
            'message' => '2FA has been removed successfully.',
        ]);
    }
}
```

* Change `toJson()` visibility to public
* Change `process()` method and made the `$request` param optional

```php
public function store(UsersEditor $editor)
{
  return $editor->process();
}
```